### PR TITLE
fix: be aware of possible servlet init before listener is called

### DIFF
--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiInstantiatorFactory.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiInstantiatorFactory.java
@@ -12,6 +12,7 @@ package com.vaadin.flow.osgi.support;
 import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
@@ -28,7 +29,8 @@ import com.vaadin.flow.server.VaadinServiceInitListener;
  * @since
  *
  */
-@Component(immediate = true, service = InstantiatorFactory.class)
+@Component(immediate = true, service = {
+        InstantiatorFactory.class }, scope = ServiceScope.SINGLETON)
 public class OSGiInstantiatorFactory implements InstantiatorFactory {
 
     private static final class OsgiInstantiator extends DefaultInstantiator

--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiResourceProvider.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiResourceProvider.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.server.VaadinServletService;
@@ -32,7 +33,8 @@ import com.vaadin.flow.server.VaadinServletService;
  * @since
  *
  */
-@Component
+@Component(scope = ServiceScope.SINGLETON, service = {
+        ResourceProvider.class }, immediate = true)
 public class OSGiResourceProvider implements ResourceProvider {
 
     @Override

--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiVaadinInitialization.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiVaadinInitialization.java
@@ -185,8 +185,8 @@ public class OSGiVaadinInitialization implements VaadinServiceInitListener,
         ServletContext servletContext = event.getServletContext();
 
         VaadinServletContext context = new VaadinServletContext(servletContext);
-        // ensure the context is set into the context
 
+        // ensure the lookup is set into the context
         context.getAttribute(Lookup.class, () -> new OsgiLookupImpl());
 
         Collection<Servlet> servlets = lookupAll(Servlet.class);

--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiVaadinInitialization.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiVaadinInitialization.java
@@ -206,15 +206,6 @@ public class OSGiVaadinInitialization implements VaadinServiceInitListener,
         initializerClasses.addContext(servletContext);
     }
 
-    private boolean isUninitializedServlet(Object object) {
-        if (object instanceof VaadinServlet) {
-            VaadinServlet vaadinServlet = (VaadinServlet) object;
-            return vaadinServlet.getServletConfig() != null
-                    && vaadinServlet.getService() == null;
-        }
-        return false;
-    }
-
     @Override
     public void contextDestroyed(ServletContextEvent event) {
         initializerClasses.removeContext(event.getServletContext());
@@ -308,6 +299,15 @@ public class OSGiVaadinInitialization implements VaadinServiceInitListener,
             }
         }
         return builder.toString();
+    }
+
+    private boolean isUninitializedServlet(Object object) {
+        if (object instanceof VaadinServlet) {
+            VaadinServlet vaadinServlet = (VaadinServlet) object;
+            return vaadinServlet.getServletConfig() != null
+                    && vaadinServlet.getService() == null;
+        }
+        return false;
     }
 
     private static <T> Collection<T> lookupAll(Class<T> serviceClass) {


### PR DESCRIPTION
Run Servlet::init for VaadinServlets which has not been completely initialized yet: ServletContextListener::contextInitialized  may be executed after Servlet::init and as a result servlet initialization wasn't possible.