### PR TITLE
fix: increase HTTP wait time

### DIFF
--- a/test-containers/karaf/karaf-run/src/test/java/com/vaadin/flow/karaf/smoketest/SmokeIT.java
+++ b/test-containers/karaf/karaf-run/src/test/java/com/vaadin/flow/karaf/smoketest/SmokeIT.java
@@ -39,7 +39,7 @@ public class SmokeIT extends ChromeBrowserTest {
         // separate JVM and no one waits for its readiness.
         // As a result IT tests starts immediately and this workaround is used
         // to wait when HTTP server starts to handle HTTP requests.
-        waitRootUrl(60);
+        waitRootUrl(180);
 
         super.checkIfServerAvailable();
 


### PR DESCRIPTION
The time to wait for HTTP is not enough for SNAPSHOT build. It takes
quite much time to download Karaf and start it.