### PR TITLE
chore: update flow-osgi package version

### DIFF
--- a/test-containers/pom.xml
+++ b/test-containers/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-osgi</artifactId>
-            <version>${flow.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The flow-osgi package should be project.version
and not flow.version