### PR TITLE
chore: remove client resource registration since it's not needed

### DIFF
--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/AppConfigFactoryTracker.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/AppConfigFactoryTracker.java
@@ -294,26 +294,6 @@ class AppConfigFactoryTracker extends
 
     }
 
-    private static class ClientResourceBundleTracker
-            extends ResourceBundleTracker {
-
-        private ClientResourceBundleTracker(Bundle webAppBundle,
-                String contextPath) {
-            super(webAppBundle, "com.vaadin.flow.client", contextPath);
-        }
-
-        @Override
-        protected String getResourceURI() {
-            return "/VAADIN/static/client/*";
-        }
-
-        @Override
-        protected String getResourcePath() {
-            return "/META-INF/resources/VAADIN/static/client";
-        }
-
-    }
-
     private static class PushResourceBundleTracker
             extends ResourceBundleTracker {
 
@@ -536,14 +516,7 @@ class AppConfigFactoryTracker extends
             contextPath = "/";
         }
 
-        registerClientResources(contextPath);
         registerPushResources(contextPath);
-    }
-
-    private void registerClientResources(String contextPath) {
-        ResourceBundleTracker resourceBoundleTracker = new ClientResourceBundleTracker(
-                webAppBundle, contextPath);
-        resourceBoundleTracker.open();
     }
 
     private void registerPushResources(String contextPath) {


### PR DESCRIPTION
WARNING: this removal is valid only in the master branch where client engine resources are not stored inside flow-client bundle at all. The client engine JS is copied into the project during the build and bundled by webpack. As a result it's available via the project resource (instead of flow-client bundle resource). Client engine resource registration is still needed in the previous Flow versions where the resources are located inside /VAADIN/static/client in the flow-client jar.