### PR TITLE
chore: Fix plugin conf to generate asc files and javadoc properly

### DIFF
--- a/flow-osgi/pom.xml
+++ b/flow-osgi/pom.xml
@@ -139,7 +139,7 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
@@ -153,7 +153,7 @@
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <sonar.issuesReport.console.enable>true
         </sonar.issuesReport.console.enable>
         <sonar.issuesReport.html.enable>true</sonar.issuesReport.html.enable>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
@@ -411,9 +410,6 @@
                     <name>!release</name>
                 </property>
             </activation>
-            <properties>
-                <maven.javadoc.skip>false</maven.javadoc.skip>
-            </properties>
             <modules>
                 <module>test-containers</module>
             </modules>


### PR DESCRIPTION
Change plugins phase to run before gpg plugin in vaadin-parent, and enable javadoc by default.