### PR TITLE
fix: let OSGiStaticFileHandler serve vaadinPush script

### DIFF
--- a/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiStaticFileHandlerFactory.java
+++ b/flow-osgi/src/main/java/com/vaadin/flow/osgi/support/OSGiStaticFileHandlerFactory.java
@@ -11,6 +11,8 @@ package com.vaadin.flow.osgi.support;
 
 import java.net.URL;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
@@ -18,6 +20,7 @@ import com.vaadin.flow.server.StaticFileHandler;
 import com.vaadin.flow.server.StaticFileHandlerFactory;
 import com.vaadin.flow.server.StaticFileServer;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
  * OSGi {@link StaticFileHandlerFactory} service implementation.
@@ -37,6 +40,24 @@ public class OSGiStaticFileHandlerFactory implements StaticFileHandlerFactory {
 
         @Override
         protected URL getStaticResource(String path) {
+            String relativePath = path.replaceFirst("^/", "");
+            if (ApplicationConstants.VAADIN_PUSH_JS.equals(relativePath)
+                    || ApplicationConstants.VAADIN_PUSH_DEBUG_JS
+                            .equals(relativePath)) {
+                return getPushResource(relativePath);
+            }
+            return null;
+        }
+
+        private URL getPushResource(String path) {
+            Bundle[] bundles = FrameworkUtil
+                    .getBundle(OSGiStaticFileHandlerFactory.class)
+                    .getBundleContext().getBundles();
+            for (Bundle bundle : bundles) {
+                if ("com.vaadin.flow.push".equals(bundle.getSymbolicName())) {
+                    return bundle.getResource("META-INF/resources/" + path);
+                }
+            }
             return null;
         }
 


### PR DESCRIPTION
## Description

Requests to vaadinPush.js script are no more relative to context path
but to the servlet path, so content is always provided by Vaadin servlet.
This change intercepts requests for vaadinPush scripts and retrieves
contents from flow-push bundle.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
