### PR TITLE
chore: branch out a new minor for Vaadin 23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 This project provides an integration with Vaadin and OSGi environments.
 
-master | Vaadin 23 / Flow 10.0 | JDK11
+master | Vaadin 23.1 / Flow 23.1 | JDK11
+8.0    | Vaadin 23.0 / Flow 23.0 | JDK11
 7.0    | Vaadin 22 / Flow 9.0  | JDK8

--- a/flow-osgi/pom.xml
+++ b/flow-osgi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-osgi-project</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-osgi</artifactId>
     <name>Flow OSGi Support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>flow-osgi-project</artifactId>
     <name>Flow OSGi</name>
     <packaging>pom</packaging>
-    <version>8.0-SNAPSHOT</version>
+    <version>8.1-SNAPSHOT</version>
 
     <parent>
         <groupId>com.vaadin</groupId>

--- a/test-containers/bnd-tools-smoke-test/app/pom.xml
+++ b/test-containers/bnd-tools-smoke-test/app/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>bnd-tools-smoke-test</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/test-containers/bnd-tools-smoke-test/pom.xml
+++ b/test-containers/bnd-tools-smoke-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-osgi-test-containers</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/test-containers/bnd-tools-smoke-test/test-project/pom.xml
+++ b/test-containers/bnd-tools-smoke-test/test-project/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>bnd-tools-smoke-test</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>bnd-test-project</artifactId>
     <properties>
@@ -29,7 +29,7 @@
             <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
 
         <!-- Added to provide logging output as Flow uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->
@@ -109,7 +109,7 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <!--This plugin's configuration is used to store Eclipse 
+                <!--This plugin's configuration is used to store Eclipse
                     m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>

--- a/test-containers/felix-jetty/pom.xml
+++ b/test-containers/felix-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-osgi-test-containers</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-test-felix-jetty-server</artifactId>
@@ -23,7 +23,7 @@
     </properties>
 
     <dependencies>
-    
+
         <!--  test views dependencies -->
         <dependency>
            <groupId>com.vaadin</groupId>
@@ -32,7 +32,7 @@
            <type>jar</type>
            <classifier>ui</classifier>
         </dependency>
-        
+
         <!--  its views dependencies -->
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -41,7 +41,7 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        
+
 
         <dependency>
             <groupId>net.bytebuddy</groupId>
@@ -97,8 +97,8 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Those dependencies are need for OSGi container where this bundle 
-            will be deployed. They will be copied into the bundle folder of OSGi container 
+        <!-- Those dependencies are need for OSGi container where this bundle
+            will be deployed. They will be copied into the bundle folder of OSGi container
             and automatically installed form there. -->
 
         <dependency>

--- a/test-containers/karaf/karaf-run/pom.xml
+++ b/test-containers/karaf/karaf-run/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>karaf-test-project-parent</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>karaf-test-project-run</artifactId>
 
@@ -37,7 +37,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -65,7 +65,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
     </build>
 

--- a/test-containers/karaf/karaf-test-project/pom.xml
+++ b/test-containers/karaf/karaf-test-project/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>karaf-test-project-parent</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>karaf-test-project</artifactId>
     <properties>
@@ -54,7 +54,7 @@
     <build>
         <pluginManagement>
             <plugins>
-                <!--This plugin's configuration is used to store Eclipse 
+                <!--This plugin's configuration is used to store Eclipse
                     m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>

--- a/test-containers/karaf/pom.xml
+++ b/test-containers/karaf/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-osgi-test-containers</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>karaf-test-project-parent</artifactId>
     <properties>

--- a/test-containers/pom.xml
+++ b/test-containers/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-osgi-project</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>8.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-osgi-test-containers</artifactId>
     <name>Flow tests</name>
@@ -268,12 +268,12 @@
             </properties>
         </profile>
         <profile>
-            <!-- This profile and the next one "bnd-tools" should be mutually 
+            <!-- This profile and the next one "bnd-tools" should be mutually
             exclusive and should NOT be executed in the same maven run!
             The problem is: they both use execution maven plugin to start the OSGi container
             which doesn't stop when ITs are finished. It stops only when (maven) JVM exits.
-            As a result one container will still be active when ITs from another 
-            module starts. That will not allow another OSGi container starts. 
+            As a result one container will still be active when ITs from another
+            module starts. That will not allow another OSGi container starts.
             -->
             <id>non-bnd-tools</id>
             <activation>
@@ -285,12 +285,12 @@
             </modules>
         </profile>
         <profile>
-            <!-- This profile and the above one "felix-jetty" should be mutually 
+            <!-- This profile and the above one "felix-jetty" should be mutually
             exclusive and should NOT be executed in the same maven run!
             The problem is: they both use execution maven plugin to start the OSGi container
             which doesn't stop when ITs are finished. It stops only when (maven) JVM exits.
-            As a result one container will still be active when ITs from another 
-            module starts. That will not allow another OSGi container starts. 
+            As a result one container will still be active when ITs from another
+            module starts. That will not allow another OSGi container starts.
             -->
             <id>bnd-tools</id>
             <modules>
@@ -298,7 +298,7 @@
             </modules>
         </profile>
     </profiles>
-    
+
 
 </project>
 


### PR DESCRIPTION
OSGi master is not compatible with Vaadin 23.0 anymore because of License Checker update, thus, a new branch `8.0` created and version bumped.