### PR TITLE
chore: bump wagon-ssh-external from 2.9 to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ssh-external</artifactId>
-                <version>2.9</version>
+                <version>3.5.2</version>
             </extension>
         </extensions>
 


### PR DESCRIPTION
Should fix an API incompatibility issue with maven-deploy-plugin