### PR TITLE
chore: downgrade karaf maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <testbench.version>6.3.0</testbench.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
-        <karaf-maven-plugin.version>4.4.1</karaf-maven-plugin.version>
+        <karaf-maven-plugin.version>4.4.0</karaf-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 
         <!-- OSGi -->


### PR DESCRIPTION
Version 4.4.1 causes compatibility issues deploy plugin
because of mixed version of wagon artifacts
