### PR TITLE
chore: bump byte-buddy to 1.14.9

### DIFF
--- a/test-containers/felix-dependencies-only/pom.xml
+++ b/test-containers/felix-dependencies-only/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.12.1</version>
+            <version>1.14.9</version>
         </dependency>
 
         <dependency>

--- a/test-containers/felix-jetty/pom.xml
+++ b/test-containers/felix-jetty/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.12.1</version>
+            <version>1.14.9</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Aligns with Flow 23.3 and fixes dependency resolution issue.