### PR TITLE
test: pin commons-io to Flow required version

### DIFF
--- a/test-containers/felix-jetty/pom.xml
+++ b/test-containers/felix-jetty/pom.xml
@@ -118,6 +118,11 @@
             <artifactId>commons-fileupload</artifactId>
             <version>1.5</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
Flow 23.4 introduces `CustomBrowserTooOldPageIT` test that triggers the `UnsupportedBrowserHandler` that is using a method from commons-io `IOUtils` class that is not available in the library version provided by felix