### PR TITLE
test: bump flow to 23.6-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <bnd.version>6.1.0</bnd.version>
         <osgi.core.version>7.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
-        <flow.version>23.5-SNAPSHOT</flow.version>
+        <flow.version>23.6-SNAPSHOT</flow.version>
 
         <maven.test.skip>false</maven.test.skip>
 

--- a/test-containers/bnd-tools-smoke-test/app/pom.xml
+++ b/test-containers/bnd-tools-smoke-test/app/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/test-containers/felix-jetty/pom.xml
+++ b/test-containers/felix-jetty/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Also bumps commons-fileupload to 1.6.0 in test modules
