### PR TITLE
chore: bump license-checker to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.13.4</version>
+                <version>2.3.0</version>
             </dependency>
 
             <!-- Test dependencies -->

--- a/test-containers/felix-dependencies-only/pom.xml
+++ b/test-containers/felix-dependencies-only/pom.xml
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.15.0</version>
+            <version>5.18.1</version>
         </dependency>
 
     </dependencies>

--- a/test-containers/felix-jetty/pom.xml
+++ b/test-containers/felix-jetty/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.15.0</version>
+            <version>5.18.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Also pins compatible JNA dependency
